### PR TITLE
Old oop style parallel support

### DIFF
--- a/src/@dseries/dseries.m
+++ b/src/@dseries/dseries.m
@@ -156,7 +156,9 @@ switch nargin
         ts.tex = name2tex(ts.name);
         ts.dates = dates(1,1):dates(1,1)+(nobs(ts)-1);
     elseif isstruct(varargin{1})
-        error( 'Hello!' );
+        ts = varargin{1};
+        ts.dates = dates( ts.dates );
+        ts = class( ts, 'dseries' );
     end
   case {2,3,4}
     if isequal(nargin,2) && ischar(varargin{1}) && isdates(varargin{2})

--- a/src/@dseries/dseries.m
+++ b/src/@dseries/dseries.m
@@ -87,7 +87,17 @@ if nargin>0 && ischar(varargin{1}) && isequal(varargin{1},'initialize')
     return
 end
 
-ts = evalin('base','emptydseriesobject');
+try
+    ts = evalin('base','emptydseriesobject');
+catch
+    ts = struct;
+    ts.data  = [];
+    ts.name  = {};
+    ts.tex   = {};
+    ts.dates = dates();
+    ts = class(ts,'dseries');
+    assignin('base','emptydseriesobject',ts);
+end
 
 switch nargin
   case 0
@@ -145,6 +155,8 @@ switch nargin
         ts.name = default_name(vobs(ts));
         ts.tex = name2tex(ts.name);
         ts.dates = dates(1,1):dates(1,1)+(nobs(ts)-1);
+    elseif isstruct(varargin{1})
+        error( 'Hello!' );
     end
   case {2,3,4}
     if isequal(nargin,2) && ischar(varargin{1}) && isdates(varargin{2})


### PR DESCRIPTION
Contains two improvements.

 1. Supports initialization from a structure, which is necessary for one work round to this issue: https://github.com/DynareTeam/dynare/issues/1400 .
 2. Ensures the emptydatesobject is always initialized. Again this is necessary in a parallel context as initialize might not have been called on parallel workers. (For example, the pool may have collapsed and restarted.)

See also my related pull requests to dynare and dates.